### PR TITLE
feat: 프로필 수정 기능 피드백 내용 적용

### DIFF
--- a/src/components/Common/Profile/PropfileStyle.ts
+++ b/src/components/Common/Profile/PropfileStyle.ts
@@ -8,5 +8,5 @@ export const ProfileStyle = styled.div`
 
 export const ProfileImage = styled(Image)`
   object-fit: contain;
-  border-radius: 50px;
+  border-radius: 50%;
 `;

--- a/src/components/Profile/ProfileEdit.tsx
+++ b/src/components/Profile/ProfileEdit.tsx
@@ -1,8 +1,8 @@
-import React, { ChangeEvent, Dispatch, SetStateAction, useCallback, useRef, useState } from 'react';
+import React, { ChangeEvent, Dispatch, SetStateAction, useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { QueryObserverResult, RefetchOptions, RefetchQueryFilters } from 'react-query';
 
-import { Button, Icon, Input, Profile, Text } from '@components/Common';
+import { Button, Input, Text } from '@components/Common';
 import { NICKNAME_VALIDATION } from '@constants/validation';
 
 import { UserNicknameType, UserProfileType } from '@/types/profile';
@@ -14,6 +14,7 @@ import { useProfileMutation } from '@api/queries/users';
 
 import * as SignupStyle from '@components/Signup/SignupPageStyle';
 import * as Styled from './ProfileStyle';
+import ProfileImageEdit from './ProfileImageEdit';
 
 interface ProfileEditPropsType {
   userData?: UserProfileType;
@@ -29,7 +30,6 @@ function ProfileEdit({ userData, setIsEditProfile, refetch }: ProfileEditPropsTy
     formState: { errors },
     handleSubmit,
   } = useForm<FormRegisterType>();
-  const imageInput = useRef<HTMLInputElement>(null);
 
   const [isFormErrorState, setIsFormErrorState] = useState<boolean>(false);
   const [nicknameErrorMessage, setNicknameErrorMessage] = useState<string>('');
@@ -58,12 +58,6 @@ function ProfileEdit({ userData, setIsEditProfile, refetch }: ProfileEditPropsTy
     },
   });
 
-  const handleUploadImage = useCallback(() => {
-    if (imageInput.current) {
-      imageInput.current.click();
-    }
-  }, []);
-
   const handleEditProfileSubmit = useCallback((userNickname: UserNicknameType) => {
     const formData = new FormData();
     formData.append('img', new File([], 'empty'));
@@ -84,30 +78,13 @@ function ProfileEdit({ userData, setIsEditProfile, refetch }: ProfileEditPropsTy
 
   return (
     <>
-      <Styled.UserImageNickname>
-        {/* 프로필 이미지 수정 */}
-        <Styled.EditUserImageWrapper>
-          <form encType="multipart/form-data">
-            <input
-              type="file"
-              accept="image/jpg,image/png,/image/jpeg"
-              name="file"
-              hidden
-              onChange={(e) => handleEditImage(e)}
-              ref={imageInput}
-            />
-          </form>
-          {userData?.profileImg.url && (
-            <Profile profileUrl={userData?.profileImg.url} alt={userData?.profileImg.name} size={128} />
-          )}
-          <Styled.ImageEditButton onClick={handleUploadImage}>
-            <Icon type="profile-edit" />
-          </Styled.ImageEditButton>
-        </Styled.EditUserImageWrapper>
-        <Text size="textL" hasBold>
-          {userData?.nickname}
-        </Text>
-      </Styled.UserImageNickname>
+      {userData && (
+        <ProfileImageEdit
+          imageUrl={userData?.profileImg.url}
+          imageName={userData?.nickname}
+          _onChange={(e) => handleEditImage(e)}
+        />
+      )}
 
       {/* 닉네임 수정 */}
       <Styled.UserNickname>

--- a/src/components/Profile/ProfileImageEdit.tsx
+++ b/src/components/Profile/ProfileImageEdit.tsx
@@ -1,0 +1,46 @@
+import { ChangeEvent, useCallback, useRef } from 'react';
+
+import { Icon, Profile, Text } from '@components/Common';
+import * as Styled from './ProfileStyle';
+
+interface ProfileImageEditPropsType {
+  imageUrl?: string;
+  imageName?: string;
+  _onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+}
+
+function ProfileImageEdit({ imageUrl, imageName, _onChange }: ProfileImageEditPropsType) {
+  const imageInput = useRef<HTMLInputElement>(null);
+
+  const handleUploadImage = useCallback(() => {
+    if (imageInput.current) {
+      imageInput.current.click();
+    }
+  }, []);
+
+  return (
+    <Styled.UserImageNickname>
+      <Styled.EditUserImageWrapper>
+        <form encType="multipart/form-data">
+          <input
+            type="file"
+            accept="image/jpg,image/png,/image/jpeg"
+            name="file"
+            hidden
+            onChange={_onChange}
+            ref={imageInput}
+          />
+        </form>
+        {imageUrl && <Profile profileUrl={imageUrl} alt={imageName} size={128} />}
+        <Styled.ImageEditButton onClick={handleUploadImage}>
+          <Icon type="profile-edit" />
+        </Styled.ImageEditButton>
+      </Styled.EditUserImageWrapper>
+      <Text size="textL" hasBold>
+        {imageName}
+      </Text>
+    </Styled.UserImageNickname>
+  );
+}
+
+export default ProfileImageEdit;


### PR DESCRIPTION
수정 사항
- #109 
- 프로필 페이지에서 이미지 `border-radius` 수정
- 프로필 페이지, 프로필 수정 페이지 모두 프로필 이미지 수정 가능하도록 수정